### PR TITLE
Add Job ad for Junior Analyst

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -15,3 +15,25 @@
                 "For remote working: Core working hours during GMT daylight. 5h overlap required."
                 ]
   references: Github-profile
+
+- title:  Junior Analyst (50%)
+  hash:   junior-analyst
+  tags:   [Google Analytics, RJMetrics, R, Excel, SQL]
+  intro:  We are looking for a Junior Analyst, with a flair for statistics, numerical math and data. We will provide you with a good salary and very interesting and intellectually challenging tasks, so we make sure you won't get bored and even might be able to expand your horizon.
+  tasks:  [
+          "Set up and maintain datawarehouse (RJMetrics)",
+          "Sync all relevant data (from web application, google analytics etc)",
+          "Understand schema",
+          "Define materialization of normalized data into data warehouse dimensions",
+          "Understand business domain and related metrics",
+          "Define data warehouse metrics accordingly",
+          "Exploratory data mining",
+          "Extract, transform and analyze existing data sources (sql, R, Excel)"
+          ]
+  requirements: [
+                "50% work in Basel (partial remote possible)",
+                "Basics about data warehousing",
+                "Background in statistics and numerical math",
+                "Experience with applying math and statistics for business analytics"
+                ]
+  references: CV


### PR DESCRIPTION
Could you please add a job ad on with the following text:

"Junior Analyst (50%)

We are looking for a Junior Analyst, with a flair for statistics, numerical math and data. We will provide you with a good salary and very interesting and intellectually challenging tasks, so we make sure you won't get bored and even might be able to expand your horizon. 

You can expect the following tasks: 
- Set up and maintain datawarehouse (RJMetrics)
- Sync all relevant data (from web application, google analytics etc)
- Understand schema
- Define materialization of normalized data into data warehouse dimensions
- Understand business domain and related metrics
- Define data warehouse metrics accordingly
- Exploratory data mining
- Extract, transform and analyze existing data sources (sql, R, Excel)

Requirements:
-50% work in Basel (partial remote possible)
- Basics about data warehousing
- Background in statistics and numerical math
- Experience with applying math and statistics for business analytics"


